### PR TITLE
Allow 'sel' property to be a string selector in case the target does not exist when you create the Trip Object

### DIFF
--- a/src/trip.js
+++ b/src/trip.js
@@ -369,8 +369,8 @@
              *  }
              */
             if ( typeof o.sel === 'undefined' ||
-                    o.sel.length === 0 ||
                     o.sel === null ||
+                    o.sel.length === 0 ||
                     typeof o.content === 'undefined' ) {
 
                 this.console.warn("Your tripData is not valid in obj :" + o +".");


### PR DESCRIPTION
Hi!

When you create a new Trip object, as it is right now, all elements that go into the sel property of the different steps must exist in the DOM at that moment.

I have changed the showCurrentTrip function so that sel may also be a string selector for an element that doesn't exists in the moment you create the Trip, but may start existing in the DOM as a consequence of the actions you perform in the trip callbacks.

Also, I have changed checkTripData, as it was crashing in case the selector didn't match anything in the DOM (jQuery returns a 0 length wrapper object), and also if you passed a null sel to the object.... so now we check for those cases of the sel property and, in case the tripData is wrong, the false value we return is used in showCurrentTrip to avoid executing setTripBlock, showTripBlock and showExpose, which were crashing in case no sel object was found. 
In this case, we just show the currentStep and then continue with the next correct step, instead of crashing.

I have set up an example of the index page, with
- The target of the last hint being inserted in the callback of the first step.
- The target of the second step not existing at all in the dom trying to cause a crash

You can find the example here: https://dl.dropboxusercontent.com/u/11769257/Trip.js/index.html

This is my first ever pull request so I hope you find it useful :)
