### PR TITLE
Handle wrong tripData correctly

### DIFF
--- a/src/trip.js
+++ b/src/trip.js
@@ -37,7 +37,8 @@
         this.$root = $('body, html');
         // default dir is next (forwards)
         this.$dir = 'next';
-
+        // we store here if the last tripData checked was correct or not
+        this.$tripDataOk = true;
         // save the current trip index
         this.tripIndex = this.settings.tripIndex;
         this.timer = null;
@@ -239,8 +240,8 @@
             }
 
             // show block
-            var tripDataOk = this.checkTripData(o);
-            if(tripDataOk) {
+            this.$tripDataOk = this.checkTripData(o);
+            if(this.$tripDataOk) {
                 this.setTripBlock(o);
                 this.showTripBlock(o);
 
@@ -250,7 +251,11 @@
             } else {
                 if( this.$dir === 'next' ) {
                     this.increaseIndex();
-                    this.showCurrentTrip(this.getCurrentTripObject());
+                    if( !this.isLast() ) {
+                        this.showCurrentTrip(this.getCurrentTripObject());
+                    } else {
+                        this.doLastOperation();
+                    }
                 }else if( this.$dir === 'prev' ) {
                     this.decreaseIndex();
                     this.showCurrentTrip(this.getCurrentTripObject());
@@ -314,23 +319,26 @@
             // next to o
             this.showCurrentTrip( tripObject );
 
-            // show the progress bar
-            this.showProgressBar( delay );
-            this.progressing = true;
+            // only set timer and run callback if the tripData was correct
+            if( this.$tripDataOk ) {
+                // show the progress bar
+                this.showProgressBar( delay );
+                this.progressing = true;
 
-            // set timer to show next
-            this.timer = new Timer(function() {
+                // set timer to show next
+                this.timer = new Timer(function() {
 
-                // XXX
-                // If we get here, it means that we have finished a step within a trip.
+                    // XXX
+                    // If we get here, it means that we have finished a step within a trip.
 
-                if ( that.hasCallback() ) {
-                   that.getCurrentTripObject().callback( that.tripIndex );
-                }
+                    if ( that.hasCallback() ) {
+                       that.getCurrentTripObject().callback( that.tripIndex );
+                    }
 
-                that.next();
+                    that.next();
 
-            }, delay);
+                }, delay);
+            }            
         },
 
         isFirst : function() {


### PR DESCRIPTION
Hi again!

If have thought a way to handle steps with wrong data.
- We store the current direction of the flow, in a var that tells us if we are going forward of backwards, and set this var in next and prev functions.
- When we find a wrong trip data, instead of repeating current step, we check the current direction of the Trip and increase or decrease the index, and try to showCurrentTrip again. If we are in the last step, we only doLastOperation(). Also, what before was the local var tripDataOk, is now a property that tells us if the last checked step was correct.
- In showCurrentTrip, we check the property $tripDataOk to see if we have to set a timer and run the callback for the current step. If this was a wrong step, we should not set any timer, as we are calling showCurrentTrip with the next step already.

As before, you can check this change here: https://dl.dropboxusercontent.com/u/11769257/Trip.js/index.html

The step after step 0 is WRONG (as before). Also, if you skip step0, thus, not executing its callback, then for the last step, the div that was inserted in step0 callback won't exist, so the last step will fail, and you will be able to check that the Trip succesfully ends even if the last step is wrong.

I hope you find everything ok, and if something is wrong, please don't hesitate to close the pull request and tell me any error :D 

Regards.
