### PR TITLE
Set canGoNext and canGoPrev for individual step

### DIFF
--- a/src/trip.js
+++ b/src/trip.js
@@ -394,7 +394,7 @@
 
         canGoPrev: function() {
             var trip        = this.tripData[ this.tripIndex ],
-                canGoPrev   = trip.canGoPrev || this.settings.canGoPrev;
+                canGoPrev   = typeof trip.canGoPrev != 'undefined' ? trip.canGoPrev : this.settings.canGoPrev;
 
             if ( typeof canGoPrev === "function" ) {
                 canGoPrev = canGoPrev.call(trip);
@@ -405,7 +405,7 @@
 
         canGoNext: function() {
             var trip        = this.tripData[ this.tripIndex ],
-                canGoNext   = trip.canGoNext || this.settings.canGoNext;
+                canGoNext   = typeof trip.canGoNext != 'undefined' ? trip.canGoNext : this.settings.canGoNext;
 
             if ( typeof canGoNext === "function" ) {
                 canGoNext = canGoNext.call(trip);


### PR DESCRIPTION
Global settings for `canGoNext` and `canGoPrev` were overriding the setting for an individual step if it was set to false.