### PR TITLE
If string passed as selector, convert to jQuery object, then restore to string.

### DIFF
--- a/src/trip.js
+++ b/src/trip.js
@@ -255,6 +255,7 @@
             // handles an element that doesn't exist yet when you create
             // this Trip.
             if(typeof o.sel === 'string') {
+                var sel = o.sel;
                 o.sel = $(o.sel);
             }
 
@@ -280,6 +281,10 @@
 
             if ( o.expose ) {
                 this.showExpose( o.sel );
+            }
+            
+            if (typeof sel == 'string') {
+                o.sel = sel;
             }
         },
 


### PR DESCRIPTION
The problem with converting the selector into a jQuery object and leaving it as one is if the stored object gets deleted and remade (i.e. an ajax dialog window), the stored object is now incorrect. If a string is passed you can assume you always want the most current existing version of that selector passed.