### PR TITLE
allow to configure the placement of the overlay

### DIFF
--- a/src/trip.js
+++ b/src/trip.js
@@ -50,6 +50,7 @@
       showCloseBox: false,
       showHeader: false,
       skipUndefinedTrip: false,
+      overlayHolder: 'body',
 
       // navigation
       showNavigation: false,
@@ -1095,7 +1096,7 @@
             zIndex: this.settings.overlayZindex
           });
 
-        $('body').append($overlay);
+        $(this.settings.overlayHolder).append($overlay);
       }
     },
 


### PR DESCRIPTION
Due to stacking frames[1], sometimes placing the overlay in the `<body>` just doesn't work (because the element you're trying to highlight is in a higher stacking frame).

This happens a lot if you use, say bootstrap templates, that contains many relative positioned elements. This 2-liner let's you specify where to put the overlay so you can overcome this issue.

[1] http://philipwalton.com/articles/what-no-one-told-you-about-z-index/
