### PR TITLE
Boolean options can not be set to True globally but False locally

### DIFF
--- a/src/trip.core.js
+++ b/src/trip.core.js
@@ -848,10 +848,12 @@ Trip.prototype = {
     var that = this;
 
     // toggle used settings
-    var showCloseBox = o.showCloseBox || this.settings.showCloseBox;
-    var showNavigation = o.showNavigation || this.settings.showNavigation;
-    var showHeader = o.showHeader || this.settings.showHeader;
-    var showSteps = o.showSteps || this.settings.showSteps;
+    var showCloseBox =
+          TripUtils.isSet(o.showCloseBox, this.settings.showCloseBox);
+    var showNavigation =
+          TripUtils.isSet(o.showNavigation, this.settings.showNavigation);
+    var showHeader = TripUtils.isSet(o.showHeader, this.settings.showHeader);
+    var showSteps = TripUtils.isSet(o.showSteps, this.settings.showSteps);
 
     // labels
     var closeBoxLabel = o.closeBoxLabel || this.settings.closeBoxLabel;

--- a/src/trip.utils.js
+++ b/src/trip.utils.js
@@ -42,6 +42,21 @@ var TripUtils = {
   },
 
   /**
+   * We will use this function to compute the resulting boolean option
+   * based on the local and global settings.
+   *
+   * @memberOf TripUtils
+   * @type {Function}
+   * @param {*} local setting, global setting
+   * @return {Boolean}
+   */
+  isSet: function(localSetting, globalSetting) {
+    return typeof localSetting !== 'undefined' ?
+           localSetting :
+           globalSetting;
+  },
+
+  /**
    * Handy wrapper of console.log
    *
    * @memberOf TripUtils


### PR DESCRIPTION
Proposed fix for issue #171.

- added an extra utility function to TripUtils `isSet()`
- which is used for the 4 Boolean options that are both in local and global settings (checked for all `show*` and `enable*` options.

I don't think this requires any documentation change.