### PR TITLE
optionally prevent click propagation out of the trip block

### DIFF
--- a/src/trip.core.js
+++ b/src/trip.core.js
@@ -81,6 +81,7 @@ function Trip() {
     showCloseBox: false,
     showHeader: false,
     skipUndefinedTrip: false,
+    stopClickPropagation: false,
 
     // navigation
     showNavigation: false,
@@ -1178,6 +1179,16 @@ Trip.prototype = {
 
         $progressSteps.append(stepCache);
       }
+
+      $tripBlock.on('click.Trip', function(e) {
+        var tripObject = that.getCurrentTripObject();
+        var tripStopClickPropagation =
+              TripUtils.isSet(tripObject.stopClickPropagation,
+                              that.settings.stopClickPropagation);
+        if (tripStopClickPropagation) {
+          e.stopPropagation();
+        }
+      });
 
       var $closeButton = $tripBlock.find('.trip-close');
       if ($closeButton) {


### PR DESCRIPTION
Proposed change. It uses the newly introduced TripUtils.isSet to check if the option should be set according to both the local and/or global settings.

Documentation has not been updated as part of this commit. Since documentation is on a distinct branch, I guess a distinct pull request would be required.