### PR TITLE
Add onError callback to allow trip to report error to user

### DIFF
--- a/docs/docs/documentations/configuration.md
+++ b/docs/docs/documentations/configuration.md
@@ -203,6 +203,17 @@ You can set a callback function triggered when Trip.js ends.
 + Default : `$.noop`
 + **Note : supported since 2.0.0+**
 
+### onError(tripIndex, tripObject, message)
+
+You can set a callback function triggered when there is an error to report.
+
+This is called when an undefined trip is encountered (returning `true` will NOT skipUndefinedTrip, whatever the value of skipUndefinedTrip global setting). It is also called if any Deferred object fails on `next` or `prev`.
+
++ Type : `Function`
++ Default : `$.noop`
++ Return : anything evaluating to `true` will stop Trip.js.
++ **Note : supported since 3.3.4+**
+
 ### onTripStart(tripIndex, tripObject)
 
 You can set a callback function triggered when each trip starts. `tripObject` is your passed JSON for this current trip, and tripIndex is the index for current trip. You can add add your customized functions in your object and call them when this callback is called.

--- a/src/trip.core.js
+++ b/src/trip.core.js
@@ -99,6 +99,7 @@ function Trip() {
     // callbacks for whole process
     onStart: noop,
     onEnd: noop,
+    onError: noop,
 
     // callbacks for each trip
     onTripStart: noop,
@@ -401,9 +402,9 @@ Trip.prototype = {
    * @type {Function}
    * @public
    */
-  next: function(tripIndex) {
+  next: function(nextTripIndex) {
     var that = this;
-    var useDifferentIndex = !isNaN(tripIndex);
+    var useDifferentIndex = !isNaN(nextTripIndex);
 
     // If we do give `tripIndex` here, it means that we want to directly jump
     // to that index no matter how. So in that case, ignore `canGoNext` check.
@@ -419,13 +420,14 @@ Trip.prototype = {
     var tripObject = this.getCurrentTripObject();
     var tripEnd = tripObject.onTripEnd || this.settings.onTripEnd;
     var tripEndDefer = tripEnd.call(this, this.tripIndex, tripObject);
+    var thisTripIndex = this.tripIndex;
 
     $.when(tripEndDefer).then(function() {
       if (useDifferentIndex) {
         if (that.timer) {
           that.timer.stop();
         }
-        that.setIndex(tripIndex);
+        that.setIndex(nextTripIndex);
         that.run();
         return;
       }
@@ -436,6 +438,10 @@ Trip.prototype = {
       else {
         that.increaseIndex();
         that.run();
+      }
+    }, function(v) {
+      if (that.settings.onError(thisTripIndex, tripObject, v)) {
+        that.stop();
       }
     });
   },
@@ -462,12 +468,17 @@ Trip.prototype = {
     var tripObject = this.getCurrentTripObject();
     var tripEnd = tripObject.onTripEnd || this.settings.onTripEnd;
     var tripEndDefer = tripEnd(this.tripIndex, tripObject);
+    var thisTripIndex = this.tripIndex;
 
     $.when(tripEndDefer).then(function() {
       if (!that.isFirst()) {
         that.decreaseIndex();
       }
       that.run();
+    }, function(v) {
+      if (that.settings.onError(thisTripIndex, tripObject, v)) {
+        that.stop();
+      }
     });
   },
 
@@ -619,6 +630,12 @@ Trip.prototype = {
     var delay = tripObject.delay || this.settings.delay;
 
     if (!this.isTripDataValid(tripObject)) {
+
+      if (this.settings.onError(this.tripIndex, tripObject, "invalid trip")) {
+        this.stop();
+        return false;
+      }
+
       // force developers to double check tripData again
       if (this.settings.skipUndefinedTrip === false) {
         TripUtils.log('Your tripData is not valid at index: ' + this.tripIndex);


### PR DESCRIPTION
This is a proposed change for issue 170.

It adds the onError callback in the settings and is set to `$.noop` by default.
If the callback returns anything that evaluates to `true`, trip will stop.

The new callback is called in three distinct cases:
- it is called if the trip data is found to be invalid. This is done before the check to skipUndefinedTrip, and if the callback returns `true`, trip will stop (which addresses the original issue)
- it is called if a `Deferred` object returned by `onTripEnd` fails in `next()`/`prev()`

The `next()` function was changed a little:
- the parameter has been renamed from tripIndex to nextTripIndex to be clearer about which tripIndex is being used.
  -The current tripIndex need to be used in the `failFilter` to the `then()` call, and is declared as `thisTripIndex` in both `next()` and `prev()`.

A draft for the documentation is also included but would certainly benefit from a review.

The `skipUndefinedTrip` behavior can remain as is (backward compatible) but could be removed in a future release as it can be replaced with a onError() handler returning false for an "invalid trip" message.
