### PR TITLE
Support for targeting elements in iframes

### DIFF
--- a/src/trip.core.js
+++ b/src/trip.core.js
@@ -970,8 +970,8 @@ Trip.prototype = {
     var blockHeight = $tripBlock.outerHeight();
     var arrowHeight = 10;
     var arrowWidth = 10;
-    var cssHorizontal;
-    var cssVertical;
+    var cssHorizontal = this.getIframeScrollLeft(o);
+    var cssVertical = this.getIframeScrollTop(o);
 
     switch (o.position) {
       case 'screen-center':
@@ -986,22 +986,22 @@ Trip.prototype = {
         cssVertical = TripConstant.TRIP_BLOCK_OFFSET_VERTICAL;
         break;
       case 'e':
-        cssHorizontal = $sel.offset().left + selWidth + arrowWidth;
-        cssVertical = $sel.offset().top - ((blockHeight - selHeight) / 2);
+        cssHorizontal += $sel.offset().left + selWidth + arrowWidth;
+        cssVertical += $sel.offset().top - ((blockHeight - selHeight) / 2);
         break;
       case 's':
-        cssHorizontal = $sel.offset().left + ((selWidth - blockWidth) / 2);
-        cssVertical = $sel.offset().top + selHeight + arrowHeight;
+        cssHorizontal += $sel.offset().left + ((selWidth - blockWidth) / 2);
+        cssVertical += $sel.offset().top + selHeight + arrowHeight;
         break;
       case 'w':
-        cssHorizontal = $sel.offset().left - (arrowWidth + blockWidth);
-        cssVertical = $sel.offset().top - ((blockHeight - selHeight) / 2);
+        cssHorizontal += $sel.offset().left - (arrowWidth + blockWidth);
+        cssVertical += $sel.offset().top - ((blockHeight - selHeight) / 2);
         break;
       case 'n':
         /* falls through */
       default:
-        cssHorizontal = $sel.offset().left + ((selWidth - blockWidth) / 2);
-        cssVertical = $sel.offset().top - arrowHeight - blockHeight;
+        cssHorizontal += $sel.offset().left + ((selWidth - blockWidth) / 2);
+        cssVertical += $sel.offset().top - arrowHeight - blockHeight;
         break;
     }
 
@@ -1108,7 +1108,11 @@ Trip.prototype = {
 
     var windowHeight = $(window).height();
     var windowTop = $(window).scrollTop();
-    var tripBlockTop = this.$tripBlock.offset().top;
+    var frameTop = this.getIframeScrollTop(o);
+    if (frameTop != 0) {
+      frameTop -= windowTop;
+    }
+    var tripBlockTop = this.$tripBlock.offset().top + frameTop;
     var tripBlockHeight = this.$tripBlock.height();
     var OFFSET = 100; // make it look nice
 
@@ -1121,6 +1125,50 @@ Trip.prototype = {
       this.$root.animate({ scrollTop: tripBlockTop - OFFSET }, 'slow');
     }
   },
+
+  /**
+     * Return the scroll top offset needed in case the element is contained in an iframe,
+     * else return 0
+     * 
+     * @memberOf Trip
+     * @type {Function}
+     * @param {Object} o
+     */
+    getIframeScrollTop : function(o) {
+      if ($(o.sel).parents('html')[0] != this.$tripBlock.parents('html')[0]) {
+        var offsetTop = 0;
+        $(document).find('iframe').each(function(index, frame) {
+          if ($(frame).contents().has($(o.sel))) {
+            offsetTop = $(frame).offset().top;
+            return false;
+          }
+        });
+        return offsetTop - $(o.sel).parents('html,body').scrollTop()
+      }
+      return 0;
+    },
+    
+    /**
+     * Return the scroll left offset needed in case the element is contained in an iframe,
+     * else return 0
+     * 
+     * @memberOf Trip
+     * @type {Function}
+     * @param {Object} o
+     */
+    getIframeScrollLeft : function(o) {
+      if ($(o.sel).parents('html')[0] != this.$tripBlock.parents('html')[0]) {
+        var offsetLeft = 0;
+        $(document).find('iframe').each(function(index, frame) {
+          if ($(frame).contents().has($(o.sel))) {
+            offsetLeft = $(frame).offset().left;
+            return false;
+          }
+        });
+        return offsetLeft - $(o.sel).parents('html,body').scrollLeft()
+      }
+      return 0;
+    },
 
   /**
    * Hide the trip block.

--- a/tests/core/iframe.html
+++ b/tests/core/iframe.html
@@ -1,0 +1,7 @@
+<html>
+  <div style="width: 400px; height: 300px">
+    <div class="iframe-step1" style="border: 1px solid; position: relative; top: 100px; left: 100px; height:50px; width: 50px"></div>
+    <div class="iframe-step2" style="border: 1px solid; position: relative; top: 200px; left: 200px; height:50px; width: 50px"></div>
+    <div class="iframe-step3" style="border: 1px solid; position: relative; top: 300px; left: 300px; height:50px; width: 50px"></div>
+  </div>
+</html>

--- a/tests/core/test.html
+++ b/tests/core/test.html
@@ -40,4 +40,7 @@
     <div class="step2"></div>
     <div class="step3"></div>
   </div>
+  
+  <iframe name="iframe parser" src="iframe.html" style ="width: 300px; height: 200px;" />
+  
 </html>

--- a/tests/core/test.html
+++ b/tests/core/test.html
@@ -41,6 +41,6 @@
     <div class="step3"></div>
   </div>
   
-  <iframe name="iframe parser" src="iframe.html" style ="width: 300px; height: 200px;" />
+  <iframe name="iframe parser" src="iframe.html" style ="position:absolute; top:0; left: 0; width: 300px; height: 200px;" />
   
 </html>

--- a/tests/core/test.js
+++ b/tests/core/test.js
@@ -123,3 +123,41 @@ asyncTest('next() can be called with index', function() {
 
   trip.start();
 });
+
+asyncTest('target inside iframe', function() {
+  var arrowHeight = 10;
+  var arrowWidth = 10;
+  
+  var frame = $('[name="iframe parser"]');
+  var trip = new Trip([
+    { sel: frame.contents().find('.iframe-step1'), position: 'n', content: 'hi1' },
+    { sel: frame.contents().find('.iframe-step2'), content: 'hi2' },
+    { sel: frame.contents().find('.iframe-step3'), content: 'hi3' }
+  ], {
+    onStart: function () {
+      frame.contents().scrollTop(frame.height() * Math.random());
+      frame.contents().scrollLeft(frame.width() * Math.random());
+    },
+    onTripChange: function(i, o) {
+      var $tripBlock = $(".trip-block");
+      var blockWidth = $tripBlock.outerWidth();
+      var blockHeight = $tripBlock.outerHeight();
+      
+      var selWidth = $(o.sel) && $(o.sel).outerWidth();
+      var selHeight = $(o.sel) && $(o.sel).outerHeight();
+      
+      var top = frame.position().top - $(o.sel).parents('html,body').scrollTop();
+      var left = frame.position().left - $(o.sel).parents('html,body').scrollLeft();
+      var blockPos = $tripBlock.position();
+      var pointerTop = $(o.sel).position().top - arrowHeight - blockHeight;
+      var pointerLeft = $(o.sel).position().left + ((selWidth - blockWidth) / 2);
+      equal(Math.round(left + pointerLeft), Math.round(blockPos.left), "Left of tripBlock is wrong for iframe element "+ i);
+      equal(Math.round(top + pointerTop), Math.round(blockPos.top), "Top of tripBlock is wrong for iframe element "+ i);
+    },
+    onEnd: function() {
+      start(); 
+    }
+  })
+
+  trip.start();
+});


### PR DESCRIPTION
jquery allows to write a selector which targets elements inside an iframe, and this can be passed to Trip.js
However, the library does not behave correctly in such case.
The PR introduces two methods to get the left and top offset of an element inside an iframe. The methods are used to scroll in place and to correctly position the $tripBlock.
A lightweight check is performed to verify if the element is indeed inside an iframe, so performance is not degraded by the new feature