### PR TITLE
Change $root to html and only use visible element

### DIFF
--- a/src/trip.core.js
+++ b/src/trip.core.js
@@ -127,7 +127,7 @@ function Trip() {
   this.$tripBlock = null;
   this.$overlay = null;
   this.$bar = null;
-  this.$root = $('html>body');
+  this.$root = $('html');
 
   // save the current trip index
   this.tripDirection = 'next';
@@ -963,7 +963,7 @@ Trip.prototype = {
         });
     }
 
-    var $sel = $(o.sel);
+    var $sel = $(o.sel + ':visible');
     var selWidth = $sel && $sel.outerWidth();
     var selHeight = $sel && $sel.outerHeight();
     var blockWidth = $tripBlock.outerWidth();


### PR DESCRIPTION
By changing $root from body to html the scrolling is fixed ( see https://stackoverflow.com/questions/46071588/chrome-61-jquery-scrolling-not-working-anymore ). Affects #190  and #195 

If the sel option is used an leads to a hidden element, the positioning will not work. As a quickfix you can make sure that only visible elements are selected by adding :visible to the CSS selector. Affects #168 

Please note that these changes have not been tested on various browsers and the ':visible' change is a bit dirty. But the changes worked for me so far and i wanted them documented for everyone else.